### PR TITLE
Allow to supply user object when sending via cloud code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 # main
 [Full Changelog](https://github.com/mtrezza/parse-server-api-mail-adapter/compare/1.0.4...master)
 
+### Breaking Changes
+*(none)*
+
+### Notable Changes
+*(none)*
+
+### Other Changes
+- Fixes undefined `user` in `localeCallback` when sending email via `Parse.Cloud.sendEmail()` (wlky, Manuel Trezza) [#18](https://github.com/mtrezza/parse-server-api-mail-adapter/pull/18)
+
 # 1.0.4
 [Full Changelog](https://github.com/mtrezza/parse-server-api-mail-adapter/compare/1.0.3...1.0.4)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The Parse Server API Mail Adapter enables Parse Server to send emails using any 
 - [Placeholders](#placeholders)
     - [Password Reset and Email Verification](#password-reset-and-email-verification)
 - [Localization](#localization)
+- [Cloud Code](#cloud-code)
+  - [Example](#example)
+  - [Parameters](#parameters)
 - [Need help?](#need-help)
 
 # Installation
@@ -48,7 +51,7 @@ You can modify the script to use any other API you like or debug-step through th
 
 # Configuration
 
-An example configuation to add the API Mail Adapter to Parse Server could look like this:
+An example configuration to add the API Mail Adapter to Parse Server could look like this:
 
 ```js
 // Declare a mail client
@@ -187,6 +190,38 @@ Files are matched with the user locale in the following order:
 1. **Locale** (locale `de-AT` matches file in folder `de-AT`)
 2. **Language** (locale `de-AT` matches file in folder `de` if there is no file in folder `de-AT`)
 3. **Default** (default file in base folder is returned if there is no file in folders `de-AT` and `de`)
+
+# Cloud Code
+
+Sending an email directly from Cloud Code is possible since Parse Server > 4.5.0. This adapter supports this convenience method.
+
+## Example
+
+If the `user` provided has an email address set, it is not necessary to set a `recipient` because the mail adapter will by default use the mail address of the `user`.
+
+```js
+Parse.Cloud.sendEmail({
+  templateName: "next_level_email",
+  placeholders: { gameScore: 100, nextLevel: 2 },
+  user: parseUser // user with email address
+});
+```
+
+## Parameters
+
+| Parameter      | Type         | Optional | Default Value | Example Value               | Description                                                                                    |
+|----------------|--------------|----------|---------------|-----------------------------|------------------------------------------------------------------------------------------------|
+| `sender`       | `String`     |          | -             | `from@example.com`          | The email sender address; overrides the sender address specified in the adapter configuration. |
+| `recipient`    | `String`     |          | -             | `to@example.com`            | The email recipient; if set overrides the email address of the `user`.                         |
+| `subject`      | `String`     |          | -             | `Welcome`                   | The email subject.                                                                             |
+| `text`         | `String`     |          | -             | `Thank you for signing up!` | The plain-text email content.                                                                  |
+| `html`         | `String`     | yes      | `undefined`   | `<html>...</html>`          | The HTML email content.                                                                        |
+| `templateName` | `String`     | yes      | `undefined`   | `customTemplate`            | The template name.                                                                             |
+| `placeholders` | `Object`     | yes      | `{}`          | `{ key: value }`            | The template placeholders.                                                                     |
+| `extra`        | `Object`     | yes      | `{}`          | `{ key: value }`            | Any additional variables to pass to the mail provider API.                                     |
+| `user`         | `Parse.User` | yes      | `undefined`   | -                           | The Parse User that the is the recipient of the email.                                         |
+
+
 
 # Need help?
 

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -1,14 +1,14 @@
-'use strict';
-
 // Simulate Parse User class
 const Parse = {
   User: class User {
     get(key) {
       switch (key) {
         case 'username':
-          return 'ExampleUsername'
+          return 'ExampleUsername';
         case 'email':
-          return 'to@example.com'
+          return 'to@example.com';
+        case 'locale':
+          return 'de-AT';
       }
     }
   }

--- a/src/ApiMailAdapter.js
+++ b/src/ApiMailAdapter.js
@@ -132,7 +132,11 @@ class ApiMailAdapter extends MailAdapter {
     if (!template) {
       throw Errors.Error.noTemplateWithName(templateName);
     }
-
+    
+    // Get user from email object
+    user = email.user;
+    
+    
     // Add template placeholders;
     // Placeholders sources override each other in this order:
     // 1. Placeholders set in the template (default)
@@ -166,7 +170,7 @@ class ApiMailAdapter extends MailAdapter {
     } else {
       // Get email parameters
       const { link, appName } = email;
-      user = email.user;
+      
 
       // Add default placeholders for templates
       Object.assign(placeholders, {

--- a/src/ApiMailAdapter.js
+++ b/src/ApiMailAdapter.js
@@ -94,7 +94,7 @@ class ApiMailAdapter extends MailAdapter {
    * @param {String} [extra] Any additional variables to pass to the mail provider API.
    * @returns {Promise<Any>} The mail provider API response.
    */
-  async sendMail({ sender, recipient, subject, text, html, templateName, placeholders, extra }) {
+  async sendMail({ sender, recipient, subject, text, html, templateName, placeholders, extra, user }) {
     return await this._sendMail({
       sender,
       recipient,
@@ -104,6 +104,7 @@ class ApiMailAdapter extends MailAdapter {
       templateName,
       placeholders,
       extra,
+      user,
       direct: true
     });
   }

--- a/src/ApiMailAdapter.js
+++ b/src/ApiMailAdapter.js
@@ -83,15 +83,16 @@ class ApiMailAdapter extends MailAdapter {
 
   /**
    * @function sendMail
-   * @desciption Sends an email.
+   * @description Sends an email.
    * @param {String} [sender] The email from address.
-   * @param {String} recipient The email recipient.
+   * @param {String} recipient The email recipient; if set overrides the email address of the `user`.
    * @param {String} [subject] The email subject.
    * @param {String} [text] The plain-text email content.
    * @param {String} [html] The HTML email content.
    * @param {String} [templateName] The template name.
-   * @param {String} [placeholders] The template placeholders.
-   * @param {String} [extra] Any additional variables to pass to the mail provider API.
+   * @param {Object} [placeholders] The template placeholders.
+   * @param {Object} [extra] Any additional variables to pass to the mail provider API.
+   * @param {Parse.User} [user] The Parse User that the is the recipient of the email.
    * @returns {Promise<Any>} The mail provider API response.
    */
   async sendMail({ sender, recipient, subject, text, html, templateName, placeholders, extra, user }) {
@@ -119,9 +120,9 @@ class ApiMailAdapter extends MailAdapter {
 
     // Define parameters
     let message;
-    const templateName = email.templateName;
-    // Get user from email object
     const user = email.user;
+    const userEmail = user ? user.get('email') : undefined;
+    const templateName = email.templateName;
 
     // If template name is not set
     if (!templateName) {
@@ -147,7 +148,7 @@ class ApiMailAdapter extends MailAdapter {
     if (email.direct) {
 
       // If recipient is not set
-      if (!email.recipient) {
+      if (!email.recipient && !userEmail) {
         throw Errors.Error.noRecipient;
       }
 
@@ -158,7 +159,7 @@ class ApiMailAdapter extends MailAdapter {
       message = Object.assign(
         {
           from: email.sender || this.sender,
-          to: email.recipient,
+          to: email.recipient || userEmail,
           subject: email.subject,
           text: email.text,
           html: email.html
@@ -174,14 +175,14 @@ class ApiMailAdapter extends MailAdapter {
       Object.assign(placeholders, {
         link,
         appName,
-        email: user.get('email'),
+        email: userEmail,
         username: user.get('username')
       });
 
       // Set message properties
       message = {
         from: this.sender,
-        to: user.get('email')
+        to: userEmail
       };
     }
 

--- a/src/ApiMailAdapter.js
+++ b/src/ApiMailAdapter.js
@@ -117,8 +117,10 @@ class ApiMailAdapter extends MailAdapter {
   async _sendMail(email) {
 
     // Define parameters
-    let user, message;
+    let message;
     const templateName = email.templateName;
+    // Get user from email object
+    const user = email.user;
 
     // If template name is not set
     if (!templateName) {
@@ -132,11 +134,7 @@ class ApiMailAdapter extends MailAdapter {
     if (!template) {
       throw Errors.Error.noTemplateWithName(templateName);
     }
-    
-    // Get user from email object
-    user = email.user;
-    
-    
+
     // Add template placeholders;
     // Placeholders sources override each other in this order:
     // 1. Placeholders set in the template (default)
@@ -170,7 +168,6 @@ class ApiMailAdapter extends MailAdapter {
     } else {
       // Get email parameters
       const { link, appName } = email;
-      
 
       // Add default placeholders for templates
       Object.assign(placeholders, {


### PR DESCRIPTION
Right now locale callbacks are not working for me, I assume due to the fact that user is always undefined when sending vie Cloud code.
This change would allow to supply the email adapter with the user object when sending an email via cloud code (I hope, haven't tested it yet, but it's a very small change)
happy about any feedback

Related issue: closes #20