### PR TITLE
Fix send email without template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 # main
 [Full Changelog](https://github.com/mtrezza/parse-server-api-mail-adapter/compare/1.0.5...master)
 
+### ⚠️ Breaking Changes
+*(none)*
+
+### 🚀 Notable Changes
+*(none)*
+
+### 🧬 Other Changes
+- Fixes failing to send email in Cloud Code without template (Manuel Trezza) [#26](https://github.com/mtrezza/parse-server-api-mail-adapter/pull/26)
+
 # 1.0.5
 [Full Changelog](https://github.com/mtrezza/parse-server-api-mail-adapter/compare/1.0.4...1.0.5)
 

--- a/spec/ApiMailAdapter.spec.js
+++ b/spec/ApiMailAdapter.spec.js
@@ -251,6 +251,26 @@ describe('ApiMailAdapter', () => {
       expect(_sendMail.calls.all()[0].args[0]).toEqual(expectedArguments);
     });
 
+    it('allows sendMail() without using a template', async () => {
+      const adapter = new ApiMailAdapter(config);
+      const apiCallbackSpy = spyOn(adapter, 'apiCallback').and.callFake(apiResponseSuccess);
+      const options = {
+        sender: config.sender,
+        recipient: 'to@example.com',
+        subject: 'ExampleSubject',
+        text: 'ExampleText',
+        html: 'ExampleHtml',
+      };
+
+      await expectAsync(adapter.sendMail(options)).toBeResolved();
+      const apiPayload = apiCallbackSpy.calls.all()[0].args[0].payload;
+      expect(apiPayload.from).toEqual(options.sender);
+      expect(apiPayload.to).toEqual(options.recipient);
+      expect(apiPayload.subject).toEqual(options.subject);
+      expect(apiPayload.text).toEqual(options.text);
+      expect(apiPayload.html).toEqual(options.html);
+    });
+
     it('passes user to callback when user is passed to sendMail()', async () => {
       const adapter = new ApiMailAdapter(config);
       const localeCallbackSpy = spyOn(config.templates.customEmailWithLocaleCallback, 'localeCallback').and.callThrough();
@@ -385,7 +405,6 @@ describe('ApiMailAdapter', () => {
       const adapter = new ApiMailAdapter(config);
       const configs = [
         { templateName: 'invalid' },
-        { templateName: 'invalid', direct: true }
       ];
       for (const config of configs) {
         await expectAsync(adapter._sendMail(config)).toBeRejectedWith(Errors.Error.noTemplateWithName('invalid'));

--- a/src/ApiMailAdapter.js
+++ b/src/ApiMailAdapter.js
@@ -125,7 +125,7 @@ class ApiMailAdapter extends MailAdapter {
     const templateName = email.templateName;
 
     // If template name is not set
-    if (!templateName) {
+    if (!templateName && !email.direct) {
       throw Errors.Error.templateConfigurationNoName;
     }
 
@@ -133,7 +133,7 @@ class ApiMailAdapter extends MailAdapter {
     const template = this.templates[templateName];
 
     // If template does not exist
-    if (!template) {
+    if (!template && !email.direct) {
       throw Errors.Error.noTemplateWithName(templateName);
     }
 
@@ -142,7 +142,12 @@ class ApiMailAdapter extends MailAdapter {
     // 1. Placeholders set in the template (default)
     // 2. Placeholders set in the email
     // 3. Placeholders returned by the placeholder callback
-    const placeholders = template.placeholders || {};
+    let placeholders = {};
+
+    // Add template placeholders
+    if (template) {
+      placeholders = Object.assign(placeholders, template.placeholders || {});
+    }
 
     // If the email is sent directly via Cloud Code
     if (email.direct) {
@@ -218,7 +223,7 @@ class ApiMailAdapter extends MailAdapter {
    */
   async _createApiData(options) {
     let { message } = options;
-    const { template, user, placeholders = {} } = options;
+    const { template = {}, user, placeholders = {} } = options;
     const { placeholderCallback, localeCallback } = template;
     let locale;
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/mtrezza/parse-server-api-mail-adapter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/mtrezza/parse-server-api-mail-adapter/issues?q=is%3Aissue).

### Issue Description
Sending an email in Cloud Code via `Parse.sendEmail()` currently only works using an email template. It does not work with specifying the email content via parameters `subject`, `text`, `html` directly.

Related issue: #25

### Approach
Allow sending email without template.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [x] Add entry to changelog